### PR TITLE
Add working version of the comicscript class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
 # comictex
-LaTeX classes for comic writing
+
+This repository defines the `comicscript` LaTeX document class, which provides macros for formatting a comic script inspired by the style suggested by writer [Fred Van Lente](http://www.fredvanlente.com/comix.html).
+
+
+## How to use
+Place `comicscript.cls` in the same folder as your tex file, and put
+
+```latex
+\documentclass[<list of class options>]{comicscript}
+```
+
+in the beginning of the file.
+See [examples/comicscript.tex](examples/comicscript.tex) for an example of how to use the class.
+
+
+## Options
+
+In addition to the options accepted by the `article` class (except for `twoside` and `twocolumn`, which are ignored), the following extra options are defined in `comicscript.cls`:
+
+**Option** | **Effect**
+--- | ---
+`paged` (default) | enables the `\page` command and numbers panel references as `<PAGE#>.<PANEL#>`
+`unpaged` | disables the `\page` command and numbers panel references simply as `<PANEL#>`
+
+
+## Commands
+
+The following commands are defined or redefined by the class:
+
+**Command** | **Effect**
+--- | ---
+`\series{series name}{issue number}` | Saves the `series name` and `issue number` to variables used in the title and header
+`\title{issue title}` | Saves the `issue title` to a variable; at least one of `\series` and `\title` must be set
+`\author{author name}` | Saves the `author name` to a variable; unlike in `article`s, not setting this throws an error
+`\maketitle` | For printing out the title, author, etc. on the first page
+`\page` | Starts a new, automatically numbered comic page
+`\panel[shot description]` | Starts a new, automatically numbered panel, with an optional shot description (wide, close-up, etc.)
+`\begin{lettering} ... \end{lettering}` | Environment for inputting lettering items
+`\dialogue{character}[descriptor]{text}` | Lettering item used for spoken dialogue
+`\narration[descriptor]{text}` | Lettering item used for narration
+`\sfx{text}` | Lettering item used for sound effects

--- a/comicscript.cls
+++ b/comicscript.cls
@@ -7,10 +7,9 @@
 \LoadClass{article}
 
 % Packages --------------------------------------------------------------------
-\RequirePackage[margin=3cm]{geometry}
+\RequirePackage[margin=1in]{geometry}
 \RequirePackage{xparse}
-\RequirePackage{titlesec}
-\RequirePackage{fancyhdr}
+\RequirePackage[pagestyles]{titlesec}
 \RequirePackage{tabularx}
 \RequirePackage{fmtcount}
 \RequirePackage{xcolor}
@@ -33,13 +32,14 @@
       {\large Written by \@author}
     \end{center}
     \thispagestyle{empty}
-    \pagestyle{fancy}
   }
 }
 
-\fancyhead{}
-\fancyhead[R]{\color{black!30}\MakeUppercase{\slshape\@series~\#\@issue~\textbullet~\@title~\textbullet~\@author}}
-\pagestyle{fancy}
+\newpagestyle{main}{
+  \sethead{}{}{\color{black!30}\MakeUppercase{\small\slshape\@series~\#\@issue~\textbullet~\@title~\textbullet~\@author}}
+  \setfoot{}{}{}
+}
+\pagestyle{main}
 
 % Sectioning commands and styling
 % \renewcommand{\thesubsection}{\arabic{subsection}}

--- a/comicscript.cls
+++ b/comicscript.cls
@@ -1,9 +1,25 @@
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{comicscript}[2020/10/07 Comic Script]
+\ProvidesClass{comicscript}[2020/10/09 Comic Script]
 
 % Options ---------------------------------------------------------------------
+% Is the script paged or not? This affects the numbering of panel labels
+\newif\ifcomicscript@unpaged
+\comicscript@unpagedfalse
+\DeclareOption{paged}{\comicscript@unpagedfalse}
+\DeclareOption{unpaged}{\comicscript@unpagedtrue}
+
+% Include a titlepage? This puts the output of \maketitle on its own page
+\newif\ifcomicscript@titlepage
+\comicscript@titlepagefalse
+\DeclareOption{titlepage}{\comicscript@titlepagetrue}
+\DeclareOption{notitlepage}{\comicscript@titlepagefalse}
+
+% Options passed to the article class
+\DeclareOption{twocolumn}{\OptionNotUsed}
+\DeclareOption{twoside}{\OptionNotUsed}
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
-\ProcessOptions\relax
+
+\ProcessOptions*\relax
 \LoadClass{article}
 
 % Packages --------------------------------------------------------------------
@@ -15,35 +31,71 @@
 \RequirePackage{xcolor}
 
 % Commands and settings -------------------------------------------------------
+% Handle mutually exclusive options
+\ifcomicscript@unpaged
+  \renewcommand{\thesubsection}{\arabic{subsection}}
+\fi
+
+\AtBeginDocument{
+  \ifx\@title\empty
+    \ifx\@series\empty
+      \ClassError{comicscript}{Either \noexpand\title or \noexpand\series must be given}\@ehc
+    \fi
+  \fi
+}
 
 % Variables for \maketitle and headers
-\def\@series{}
-\newcommand{\series}[1]{\def\@series{#1}}
-\newcommand{\theseries}{\@series}
-
-\def\@issue{}
-\newcommand{\issue}[1]{\def\@issue{#1}}
-\newcommand{\theissue}{\@issue}
+\def\@author{\ClassError{comicscript}{No \noexpand\author given}\@ehc}
+\gdef\@title{}
+\gdef\@series{}
+\gdef\@issue{}
+\DeclareRobustCommand\series[2]{
+  \gdef\@series{#1}
+  \gdef\@issue{#2}
+}
 
 \renewcommand{\maketitle}{
-  {
-    \begin{center}
-      {\Huge\bfseries\@series~\#\@issue~---~\@title}\\[1ex]
-      {\large Written by \@author}
-    \end{center}
-    \thispagestyle{empty}
-  }
+  \ifcomicscript@titlepage
+    \hspace{0pt}\vfill
+    \@maketitle
+    \vfill\hspace{0pt}
+    \clearpage
+  \else
+    \@maketitle
+  \fi
+}
+
+\renewcommand{\@maketitle}{
+  \begin{center}
+    \ifx\@series\empty
+      {\Huge\bfseries\@title}
+    \else
+      \ifx\@title\empty
+        {\Huge\bfseries\@series~\#\@issue}
+      \else
+        {\Huge\bfseries\@series~\#\@issue~---~\@title}
+      \fi
+    \fi
+    \medskip\par{\large Written by \@author}\bigskip
+  \end{center}
+  \thispagestyle{empty}
 }
 
 \newpagestyle{main}{
-  \sethead{}{}{\color{black!30}\MakeUppercase{\small\slshape\@series~\#\@issue~\textbullet~\@title~\textbullet~\@author}}
+  \sethead{}{}{
+    \color{black!30}\MakeUppercase{%
+      \small\slshape%
+      \ifx\@series\empty\else{\@series~\#\@issue~\textbullet~}\fi%
+      \ifx\@title\empty\else{\@title~\textbullet~}\fi%
+      \@author
+    }
+  }
   \setfoot{}{}{}
 }
 \pagestyle{main}
 
 % Sectioning commands and styling
-% \renewcommand{\thesubsection}{\arabic{subsection}}
-\newcommand{\page}{\section{Page \Numberstring{section}}}
+\ifcomicscript@unpaged\else\newcommand{\page}{\section{Page \Numberstring{section}}}\fi
 \NewDocumentCommand{\panel}{o}{\subsection{Panel \arabic{subsection}\IfNoValueTF{#1}{}{ (#1)}}}
 
 \titleformat{\section}[hang]{\normalfont\Large\bfseries}{}{0pt}{}

--- a/comicscript.cls
+++ b/comicscript.cls
@@ -1,0 +1,58 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesClass{comicscript}[2020/10/07 Comic Script]
+
+% Options
+\DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
+\ProcessOptions\relax
+\LoadClass{article}
+
+% Packages
+\RequirePackage{xparse}
+\RequirePackage[utf8]{inputenc}
+\RequirePackage[T1]{fontenc}
+\RequirePackage[sfdefault,condensed]{cabin}
+\RequirePackage[margin=2cm]{geometry}
+\RequirePackage{titling}
+\RequirePackage{titlesec}
+\RequirePackage{fancyhdr}
+\RequirePackage{tabularx}
+
+% Settings
+\setlength{\parindent}{0pt}
+\setlength{\parskip}{3pt}
+
+% Commands and variables -------------------------------------------------------
+
+% Variables for \maketitle and headers
+\def\@series{}
+\newcommand{\series}[1]{\def\@series{#1}}
+\newcommand{\theseries}{\@series}
+
+\def\@issue{}
+\newcommand{\issue}[1]{\def\@issue{#1}}
+\newcommand{\theissue}{\@issue}
+
+% Sectioning commands
+\newcommand{\page}{\section}
+\NewDocumentCommand{\panel}{o}{%
+  \IfNoValueTF{#1}
+  {\paragraph{Panel X:}}
+  {\paragraph{Panel X (#1):}}
+}
+
+% Lettering instruction commands
+\newcommand{\dialogue}[2]{
+  \begin{tabularx}{\textwidth}{p{0.03\textwidth}p{0.27\textwidth}X}
+    XX & \MakeUppercase{#1}: & #2
+  \end{tabularx}
+}
+\newcommand{\narration}[1]{
+  \begin{tabularx}{\textwidth}{p{0.03\textwidth}p{0.27\textwidth}X}
+    XX & NARRATION: & #1
+  \end{tabularx}
+}
+\newcommand{\sfx}[1]{
+  \begin{tabularx}{\textwidth}{p{0.03\textwidth}p{0.27\textwidth}X}
+    XX & SFX: & #1
+  \end{tabularx}
+}

--- a/comicscript.cls
+++ b/comicscript.cls
@@ -1,27 +1,21 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{comicscript}[2020/10/07 Comic Script]
 
-% Options
+% Options ---------------------------------------------------------------------
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
 \ProcessOptions\relax
 \LoadClass{article}
 
-% Packages
+% Packages --------------------------------------------------------------------
+\RequirePackage[margin=3cm]{geometry}
 \RequirePackage{xparse}
-\RequirePackage[utf8]{inputenc}
-\RequirePackage[T1]{fontenc}
-\RequirePackage[sfdefault,condensed]{cabin}
-\RequirePackage[margin=2cm]{geometry}
-\RequirePackage{titling}
 \RequirePackage{titlesec}
 \RequirePackage{fancyhdr}
 \RequirePackage{tabularx}
+\RequirePackage{fmtcount}
+\RequirePackage{xcolor}
 
-% Settings
-\setlength{\parindent}{0pt}
-\setlength{\parskip}{3pt}
-
-% Commands and variables -------------------------------------------------------
+% Commands and settings -------------------------------------------------------
 
 % Variables for \maketitle and headers
 \def\@series{}
@@ -32,27 +26,39 @@
 \newcommand{\issue}[1]{\def\@issue{#1}}
 \newcommand{\theissue}{\@issue}
 
-% Sectioning commands
-\newcommand{\page}{\section}
-\NewDocumentCommand{\panel}{o}{%
-  \IfNoValueTF{#1}
-  {\paragraph{Panel X:}}
-  {\paragraph{Panel X (#1):}}
+\renewcommand{\maketitle}{
+  {
+    \begin{center}
+      {\Huge\bfseries\@series~\#\@issue~---~\@title}\\[1ex]
+      {\large Written by \@author}
+    \end{center}
+    \thispagestyle{empty}
+    \pagestyle{fancy}
+  }
 }
 
+\fancyhead{}
+\fancyhead[R]{\color{black!30}\MakeUppercase{\slshape\@series~\#\@issue~\textbullet~\@title~\textbullet~\@author}}
+\pagestyle{fancy}
+
+% Sectioning commands and styling
+% \renewcommand{\thesubsection}{\arabic{subsection}}
+\newcommand{\page}{\section{Page \Numberstring{section}}}
+\NewDocumentCommand{\panel}{o}{\subsection{Panel \arabic{subsection}\IfNoValueTF{#1}{}{ (#1)}}}
+
+\titleformat{\section}[hang]{\normalfont\Large\bfseries}{}{0pt}{}
+\titleformat{\subsection}[runin]{\normalfont\bfseries}{}{0pt}{}[:]
+
 % Lettering instruction commands
-\newcommand{\dialogue}[2]{
-  \begin{tabularx}{\textwidth}{p{0.03\textwidth}p{0.27\textwidth}X}
-    XX & \MakeUppercase{#1}: & #2
-  \end{tabularx}
+\newcolumntype{R}[1]{>{\raggedleft\arraybackslash}p{#1}}
+\newenvironment{lettering}
+  {\medskip\par\noindent\tabularx{\textwidth}{ R{0.05\textwidth} p{0.25\textwidth} X }}
+  {\endtabularx}
+\newcounter{letteringitem}[section]
+\NewDocumentCommand{\letteringitem}{ m o m }{
+  \stepcounter{letteringitem}
+  \arabic{letteringitem}. & \MakeUppercase{#1}\IfNoValueTF{#2}{}{ (\MakeUppercase{#2})}: & #3
 }
-\newcommand{\narration}[1]{
-  \begin{tabularx}{\textwidth}{p{0.03\textwidth}p{0.27\textwidth}X}
-    XX & NARRATION: & #1
-  \end{tabularx}
-}
-\newcommand{\sfx}[1]{
-  \begin{tabularx}{\textwidth}{p{0.03\textwidth}p{0.27\textwidth}X}
-    XX & SFX: & #1
-  \end{tabularx}
-}
+\NewDocumentCommand{\dialogue}{ m o m }{\letteringitem{#1}[#2]{#3}}
+\NewDocumentCommand{\narration}{ o m }{\letteringitem{NARRATION}[#1]{#2}}
+\NewDocumentCommand{\sfx}{ m }{\letteringitem{SFX}{#1}}

--- a/examples/comicscript.tex
+++ b/examples/comicscript.tex
@@ -1,17 +1,13 @@
-\documentclass[a4paper,12pt]{../comicscript}
-\usepackage[sfdefault,condensed]{cabin}
+\documentclass[a4paper,12pt,unpaged]{../comicscript}
+\usepackage[default]{sourcesanspro}
 \usepackage[T1]{fontenc}
-\usepackage{lipsum}
 
-\series{My Daughter, Nova}
-\issue{1}
+\series{My Daughter, Nova}{1}
 \title{Sippy Cup}
 \author{Janus Valberg-Madsen}
 
 \begin{document}
 \maketitle
-
-\page
 
 \panel[medium-wide shot]
 Janus sits by the dinner table with his LAPTOP. 
@@ -48,15 +44,6 @@ Janus turns his head slightly, looking suspiciously towards her.
 Janus is running chasingly after Nova, who’s running away while pouring water out wildly. 
 Nova has a look of intentional mischief on her face, and Janus looks pissed. 
 Speed lines in the background.
-
-\newpage
-\page
-
-\panel
-\lipsum[1]
-
-\panel
-\lipsum[2]
 
 \end{document}
 

--- a/examples/comicscript.tex
+++ b/examples/comicscript.tex
@@ -1,26 +1,62 @@
 \documentclass[a4paper,12pt]{../comicscript}
+\usepackage[sfdefault,condensed]{cabin}
+\usepackage[T1]{fontenc}
 \usepackage{lipsum}
 
-\title{Issue Title}
-\author{Janus Valberg-Madsen}
-\series{My Comic Series}
+\series{My Daughter, Nova}
 \issue{1}
+\title{Sippy Cup}
+\author{Janus Valberg-Madsen}
 
 \begin{document}
 \maketitle
 
-\page{Page One}
+\page
+
+\panel[medium-wide shot]
+Janus sits by the dinner table with his LAPTOP. 
+Nova is standing on the floor next to him, reaching for the DRINKING BOTTLE that Janus is handing to her.
+\begin{lettering}
+    \dialogue{Nova}{\textit{\textbf{Me want water!}}} \\
+    \dialogue{Janus}{Alright, here you go. Please don't pour it this time.}
+\end{lettering}
+
+\panel[medium-close shot]
+\label{panel:drinking}
+Nova drinks from the bottle with her back turned towards Janus, who is facing away in this shot.
+\begin{lettering}
+    \sfx{Sip, sip}
+\end{lettering}
+
+\panel[identical to \ref{panel:drinking}]
+Nova stops drinking and side-eyes towards Janus mischievously.
+
+\panel[wide shot]
+\label{panel:pouring}
+Nova starts slightly turning the bottle upside down, looking concentrated on what she’s doing. 
+Janus is still looking at his laptop, but aware of what’s happening. 
+We see Janus’ face in the foreground, in shade, eyes looking down.
+\begin{lettering}
+    \dialogue{Janus}{Nova... do \textit{not}... pour... the water.}
+\end{lettering}
+
+\panel[identical to \ref{panel:pouring}]
+Nova keeps turning the bottle around, getting a mischievous look on her face.
+Janus turns his head slightly, looking suspiciously towards her.
+
+\panel[wide shot]
+Janus is running chasingly after Nova, who’s running away while pouring water out wildly. 
+Nova has a look of intentional mischief on her face, and Janus looks pissed. 
+Speed lines in the background.
+
+\newpage
+\page
 
 \panel
 \lipsum[1]
 
-\dialogue{Main Character}{Well, well, well. If it isn't the consequences of my own actions!}
-
-\panel[wide shot]
+\panel
 \lipsum[2]
-
-\narration{\textit{There is no way I'm escaping this alive}}
-\sfx{Badoom, badoom}
 
 \end{document}
 

--- a/examples/comicscript.tex
+++ b/examples/comicscript.tex
@@ -1,0 +1,30 @@
+\documentclass[a4paper,12pt]{../comicscript}
+\usepackage{lipsum}
+
+\title{Issue Title}
+\author{Janus Valberg-Madsen}
+\series{My Comic Series}
+\issue{1}
+
+\begin{document}
+\maketitle
+
+\page{Page One}
+
+\panel
+\lipsum[1]
+
+\dialogue{Main Character}{Well, well, well. If it isn't the consequences of my own actions!}
+
+\panel[wide shot]
+\lipsum[2]
+
+\narration{\textit{There is no way I'm escaping this alive}}
+\sfx{Badoom, badoom}
+
+\end{document}
+
+%%% Local Variables:
+%%% mode: latex
+%%% TeX-master: t
+%%% End:


### PR DESCRIPTION
This PR

* Adds `comicscript.cls` with a working set of options and commands
* Documents these options and commands in the README
* Adds an example tex file using the class